### PR TITLE
fix empty host at parse_url()

### DIFF
--- a/src/MogileFS/File/Mapper/Adapter/Tracker.php
+++ b/src/MogileFS/File/Mapper/Adapter/Tracker.php
@@ -8,6 +8,7 @@
  */
 class MogileFS_File_Mapper_Adapter_Tracker extends MogileFS_File_Mapper_Adapter_Abstract
 {
+	const DEFAULT_PORT = 7001;
 	/**
 	 * Socket resource
 	 */
@@ -345,14 +346,21 @@ class MogileFS_File_Mapper_Adapter_Tracker extends MogileFS_File_Mapper_Adapter_
 
 		foreach ($options['tracker'] as $host) {
 			$parts = parse_url($host);
-			if (!isset($parts['port'])) {
-				$parts['port'] = 7001;
+			$hostname = '';
+			if (isset($parts['host'])) {
+				$hostname = $parts['host'];
+			} elseif (isset($parts['path']) && $parts['path'] == $host) {
+				$hostname = $parts['path'];
+			}
+			$port = self::DEFAULT_PORT;
+			if (isset($parts['port'])) {
+				$port = $parts['port'];
 			}
 
 			$errno = null;
 			$errstr = null;
 			$requestTimeout = isset($options['request_timeout']) ? $options['request_timeout'] : null;
-			$this->_socket = fsockopen($parts['host'], $parts['port'], $errno, $errstr, $requestTimeout);
+			$this->_socket = fsockopen($hostname, $port, $errno, $errstr, $requestTimeout);
 			if ($this->_socket) {
 				break;
 			}

--- a/tests/MogileFS/File/MapperTest.php
+++ b/tests/MogileFS/File/MapperTest.php
@@ -76,7 +76,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
 
 	public function testFetchFile()
 	{
-		$this->_testFile->setPaths(array('http://www.test.com'));
+		$this->_testFile->setPaths(array('https://www.test.com'));
 
 		$mapper = new MogileFS_File_Mapper();
 		$this->_testFile->setMapper($mapper);


### PR DESCRIPTION
for address 127.0.0.1 parse_url() returns array with one param: ['path' => '127.0.0.1'] and this array doesn't contain key 'host'.
Solution for issue #3 