### PR TITLE
method to fetch raw content from mogile fs instead of storing in a file

### DIFF
--- a/tests/MogileFS/File/MapperTest.php
+++ b/tests/MogileFS/File/MapperTest.php
@@ -140,4 +140,17 @@ class MapperTest extends PHPUnit_Framework_TestCase
 		}
 		$this->fail('Did not get MogileFS_Exception exception');
 	}
+
+    /**
+     * Test fetching resource handler
+     */
+    public function testFetchResourceHandler()
+    {
+        $mapper = new MogileFS_File_Mapper(array('adapter' => $this->_testAdapter));
+        $this->_testFile->setPaths(array('https://www.test.com'));
+
+        $fileHandler = $mapper->fetchResourceHandler($this->_testFile);
+        $this->assertTrue(is_resource($fileHandler));
+        $this->assertNotEmpty(stream_get_contents($fileHandler));
+    }
 }


### PR DESCRIPTION
This method allows to fetch the raw content from mogile fs. The use case is when you want to fetch the content without storing it in a temp file and pass through further to another cloud. For example, fetching millions of images from Mogile FS and pushing them to AWS S3. In this case, it is very useful not to create temporary files (so that server does not run out of space) and instead fetch raw binary files and push to AWS S3. 

Note: The method sends an curl request similar to fetchFile and store the result in a variable by setting CURLOPT_RETURNTRANSFER. 
